### PR TITLE
fix datatype error for single mutation runs

### DIFF
--- a/R/user_functions.R
+++ b/R/user_functions.R
@@ -537,7 +537,12 @@ infer_phylogeny = function(EvoTraceR_object, mutations_use = 'del_ins') {
   if (!dir.exists(output_dir)) {dir.create(output_dir, recursive = TRUE)}
   
   asv_bin_var = EvoTraceR_object$alignment$binary_mutation_matrix
-  barcode_var = asv_bin_var[EvoTraceR_object$reference$ref_name,]  
+  barcode_var = asv_bin_var[EvoTraceR_object$reference$ref_name,]
+  if (class(barcode_var) == "numeric") {
+    first_name <- colnames(asv_bin_var)[1]
+    barcode_var <- setNames(data.frame(barcode_var), first_name)
+    rownames(barcode_var) <- EvoTraceR_object$reference$ref_name
+  }
   if (mutations_use == 'del_ins') { 
     
     asv_bin_var = asv_bin_var %>%


### PR DESCRIPTION
For situations when there is only one informative mutation between the ref seq and the ASV(s), there is only one column in asv_bin_var, so the subset of barcode_var from asv_bin_var results in a "numeric" datatype that causes an error when using dplyr::bind_rows() with asv_bin_var. This fix ensures that barcode_var is a "data.frame" type with the correct col name (the row name of the single mutation in asv_bin_var) and row name (the ref seq name from EvoTraceR_object).